### PR TITLE
Settings refactor

### DIFF
--- a/app/src/main/java/cash/bchd/android_neutrino/Settings.java
+++ b/app/src/main/java/cash/bchd/android_neutrino/Settings.java
@@ -43,9 +43,7 @@ public class Settings {
     }
 
     void setWalletInitialized(boolean initialized) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putBoolean(INITIALIZED_KEY, initialized);
-        editor.apply();
+        putBoolean(INITIALIZED_KEY, initialized);
     }
 
     Boolean getWalletInitialized() {
@@ -53,9 +51,7 @@ public class Settings {
     }
 
     public void setMnemonic(String mnemonic) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(MNEMONIC_KEY, mnemonic);
-        editor.apply();
+        putString(MNEMONIC_KEY, mnemonic);
     }
 
     public String getMnemonic() {
@@ -63,9 +59,7 @@ public class Settings {
     }
 
     void setBlocksOnly(boolean blocksOnly) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putBoolean(BLOCKS_ONLY_KEY, blocksOnly);
-        editor.apply();
+        putBoolean(BLOCKS_ONLY_KEY, blocksOnly);
     }
 
     Boolean getBlocksOnly() {
@@ -73,9 +67,7 @@ public class Settings {
     }
 
     void setLastBalance(long balance) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putLong(LAST_BALANCE_KEY, balance);
-        editor.apply();
+        putLong(LAST_BALANCE_KEY, balance);
     }
 
     long getLastBalance() {
@@ -83,9 +75,7 @@ public class Settings {
     }
 
     void setFiatCurrency(String currency) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(FIAT_CURRENCY_KEY, currency);
-        editor.apply();
+        putString(FIAT_CURRENCY_KEY, currency);
     }
 
     String getFiatCurrency() {
@@ -93,9 +83,7 @@ public class Settings {
     }
 
     void setLastAddress(String addr) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(LAST_ADDRESS_KEY, addr);
-        editor.apply();
+        putString(LAST_ADDRESS_KEY, addr);
     }
 
     String getLastAddress() {
@@ -103,9 +91,7 @@ public class Settings {
     }
 
     void setLastBlockHeight(int blockHeight) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putInt(LAST_BLOCK_HEIGHT_KEY, blockHeight);
-        editor.apply();
+        putInt(LAST_BLOCK_HEIGHT_KEY, blockHeight);
     }
 
     int getLastBlockHeight() {
@@ -113,9 +99,7 @@ public class Settings {
     }
 
     void setLastBlockHash(String blockHash) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(LAST_BLOCK_HASH_KEY, blockHash);
-        editor.apply();
+        putString(LAST_BLOCK_HASH_KEY, blockHash);
     }
 
     String getLastBlockHash() {
@@ -123,9 +107,7 @@ public class Settings {
     }
 
     void setFeePerByte(int satPerByte) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putInt(FEE_PER_BYTE_KEY, satPerByte);
-        editor.apply();
+        putInt(FEE_PER_BYTE_KEY, satPerByte);
     }
 
     int getFeePerByte() {
@@ -133,9 +115,7 @@ public class Settings {
     }
 
     void setDefaultLabel(String label) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(DEFAULT_LABEL_KEY, label);
-        editor.apply();
+        putString(DEFAULT_LABEL_KEY, label);
     }
 
     String getDefaultLabel() {
@@ -143,9 +123,7 @@ public class Settings {
     }
 
     void setDefaultMemo(String memo) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(DEFAULT_MEMO_KEY, memo);
-        editor.apply();
+        putString(DEFAULT_MEMO_KEY, memo);
     }
 
     String getDefaultMemo() {
@@ -153,9 +131,7 @@ public class Settings {
     }
 
     void setBchdIP(String ip) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(BCHD_IP_KEY, ip);
-        editor.apply();
+        putString(BCHD_IP_KEY, ip);
     }
 
     String getBchdIP() {
@@ -163,9 +139,7 @@ public class Settings {
     }
 
     void setBchdUsername(String username) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(BCHD_USERNAME_KEY, username);
-        editor.apply();
+        putString(BCHD_USERNAME_KEY, username);
     }
 
     String getBchdUsername() {
@@ -173,9 +147,7 @@ public class Settings {
     }
 
     void setBchdPassword(String password) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(BCHD_PASSWORD_KEY, password);
-        editor.apply();
+        putString(BCHD_PASSWORD_KEY, password);
     }
 
     String getBchdPassword() {
@@ -183,9 +155,7 @@ public class Settings {
     }
 
     void setBchdCert(String cert) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(BCHD_CERT_KEY, cert);
-        editor.apply();
+        putString(BCHD_CERT_KEY, cert);
     }
 
     String getBchdCert() {
@@ -193,9 +163,7 @@ public class Settings {
     }
 
     void setEncryptionType(EncryptionType et) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(ENCRYPTION_TYPE_KEY, et.toString());
-        editor.apply();
+        putString(ENCRYPTION_TYPE_KEY, et.toString());
     }
 
     EncryptionType getEncryptionType() {
@@ -204,9 +172,7 @@ public class Settings {
     }
 
     void setInvalidPinCount(int count) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putInt(INVALID_PIN_COUNT_KEY, count);
-        editor.apply();
+        putInt(INVALID_PIN_COUNT_KEY, count);
     }
 
     int getInvalidPinCount() {
@@ -214,9 +180,7 @@ public class Settings {
     }
 
     void setLastInvalidPin(long timestamp) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putLong(LAST_INVALID_PIN_KEY, timestamp);
-        editor.apply();
+        putLong(LAST_INVALID_PIN_KEY, timestamp);
     }
 
     long getLastInvalidPin() {
@@ -224,9 +188,7 @@ public class Settings {
     }
 
     void setEncryptedPassword(String pw) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(ENCRYPTED_PASSWORD_KEY, pw);
-        editor.apply();
+        putString(ENCRYPTED_PASSWORD_KEY, pw);
     }
 
     String getEncryptedPassword() {
@@ -234,9 +196,7 @@ public class Settings {
     }
 
     void setFingerprintIv(String iv) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putString(FINGERPRINT_IV_KEY, iv);
-        editor.apply();
+        putString(FINGERPRINT_IV_KEY, iv);
     }
 
     String getFingerprintIv() {
@@ -244,9 +204,7 @@ public class Settings {
     }
 
     void setLastNotification(long timestamp) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putLong(LAST_NOTIFICATION_KEY, timestamp);
-        editor.apply();
+        putLong(LAST_NOTIFICATION_KEY, timestamp);
     }
 
     long getLastNotification() {
@@ -254,9 +212,7 @@ public class Settings {
     }
 
     void setBackupReminder(boolean reminded) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putBoolean(BACKUP_REMINDER_KEY, reminded);
-        editor.apply();
+        putBoolean(BACKUP_REMINDER_KEY, reminded);
     }
 
     Boolean getBackupReminder() {
@@ -264,9 +220,7 @@ public class Settings {
     }
 
     public void setWalletBirthday(long timestamp) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putLong(WALLET_BIRTHDAY_KEY, timestamp);
-        editor.apply();
+        putLong(WALLET_BIRTHDAY_KEY, timestamp);
     }
 
     public long getWalletBirthday() {
@@ -274,12 +228,26 @@ public class Settings {
     }
 
     void setRepoVersion(int version) {
-        SharedPreferences.Editor editor = this.prefs.edit();
-        editor.putInt(REPO_VERSION_KEY, version);
-        editor.apply();
+        putInt(REPO_VERSION_KEY, version);
     }
 
     int getRepoVersion() {
         return prefs.getInt(REPO_VERSION_KEY, 0);
+    }
+
+    private void putBoolean(final String key, final boolean val) {
+        prefs.edit().putBoolean(key, val).apply();
+    }
+
+    private void putInt(final String key, final int val) {
+        prefs.edit().putInt(key, val).apply();
+    }
+
+    private void putLong(final String key, final long val) {
+        prefs.edit().putLong(key, val).apply();
+    }
+
+    private void putString(final String key, final String val) {
+        prefs.edit().putString(key, val).apply();
     }
 }

--- a/app/src/main/java/cash/bchd/android_neutrino/Settings.java
+++ b/app/src/main/java/cash/bchd/android_neutrino/Settings.java
@@ -29,7 +29,7 @@ public class Settings {
     private static final String WALLET_BIRTHDAY_KEY = "WalletBirthday";
     private static final String REPO_VERSION_KEY = "RepoVersion";
 
-    SharedPreferences prefs;
+    private final SharedPreferences prefs;
 
     private static Settings instance;
 
@@ -42,15 +42,14 @@ public class Settings {
         return instance;
     }
 
-    public void setWalletInitialized(boolean initialized) {
+    void setWalletInitialized(boolean initialized) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putBoolean(INITIALIZED_KEY, initialized);
         editor.apply();
     }
 
-    public Boolean getWalletInitialized() {
-        boolean initialized = prefs.getBoolean(INITIALIZED_KEY, false);
-        return initialized;
+    Boolean getWalletInitialized() {
+        return prefs.getBoolean(INITIALIZED_KEY, false);
     }
 
     public void setMnemonic(String mnemonic) {
@@ -60,228 +59,208 @@ public class Settings {
     }
 
     public String getMnemonic() {
-        String mnemonic = prefs.getString(MNEMONIC_KEY, "");
-        return mnemonic;
+        return prefs.getString(MNEMONIC_KEY, "");
     }
 
-    public void setBlocksOnly(boolean blocksOnly) {
+    void setBlocksOnly(boolean blocksOnly) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putBoolean(BLOCKS_ONLY_KEY, blocksOnly);
         editor.apply();
     }
 
-    public Boolean getBlocksOnly() {
-        boolean blocksOnly = prefs.getBoolean(BLOCKS_ONLY_KEY, false);
-        return blocksOnly;
+    Boolean getBlocksOnly() {
+        return prefs.getBoolean(BLOCKS_ONLY_KEY, false);
     }
 
-    public void setLastBalance(long balance) {
+    void setLastBalance(long balance) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putLong(LAST_BALANCE_KEY, balance);
         editor.apply();
     }
 
-    public long getLastBalance() {
-        long balance = prefs.getLong(LAST_BALANCE_KEY, 0);
-        return balance;
+    long getLastBalance() {
+        return prefs.getLong(LAST_BALANCE_KEY, 0);
     }
 
-    public void setFiatCurrency(String currency) {
+    void setFiatCurrency(String currency) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(FIAT_CURRENCY_KEY, currency);
         editor.apply();
     }
 
-    public String getFiatCurrency() {
-        String currency = prefs.getString(FIAT_CURRENCY_KEY, "usd");
-        return currency;
+    String getFiatCurrency() {
+        return prefs.getString(FIAT_CURRENCY_KEY, "usd");
     }
 
-    public void setLastAddress(String addr) {
+    void setLastAddress(String addr) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(LAST_ADDRESS_KEY, addr);
         editor.apply();
     }
 
-    public String getLastAddress() {
-        String addr = prefs.getString(LAST_ADDRESS_KEY, "");
-        return addr;
+    String getLastAddress() {
+        return prefs.getString(LAST_ADDRESS_KEY, "");
     }
 
-    public void setLastBlockHeight(int blockHeight) {
+    void setLastBlockHeight(int blockHeight) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putInt(LAST_BLOCK_HEIGHT_KEY, blockHeight);
         editor.apply();
     }
 
-    public int getLastBlockHeight() {
-        int height = prefs.getInt(LAST_BLOCK_HEIGHT_KEY, 0);
-        return height;
+    int getLastBlockHeight() {
+        return prefs.getInt(LAST_BLOCK_HEIGHT_KEY, 0);
     }
 
-    public void setLastBlockHash(String blockHash) {
+    void setLastBlockHash(String blockHash) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(LAST_BLOCK_HASH_KEY, blockHash);
         editor.apply();
     }
 
-    public String getLastBlockHash() {
-        String hash = prefs.getString(LAST_BLOCK_HASH_KEY, "");
-        return hash;
+    String getLastBlockHash() {
+        return prefs.getString(LAST_BLOCK_HASH_KEY, "");
     }
 
-    public void setFeePerByte(int satPerByte) {
+    void setFeePerByte(int satPerByte) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putInt(FEE_PER_BYTE_KEY, satPerByte);
         editor.apply();
     }
 
-    public int getFeePerByte() {
-        int fee = prefs.getInt(FEE_PER_BYTE_KEY, 15);
-        return fee;
+    int getFeePerByte() {
+        return prefs.getInt(FEE_PER_BYTE_KEY, 15);
     }
 
-    public void setDefaultLabel(String label) {
+    void setDefaultLabel(String label) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(DEFAULT_LABEL_KEY, label);
         editor.apply();
     }
 
-    public String getDefaultLabel() {
-        String label = prefs.getString(DEFAULT_LABEL_KEY, "");
-        return label;
+    String getDefaultLabel() {
+        return prefs.getString(DEFAULT_LABEL_KEY, "");
     }
 
-    public void setDefaultMemo(String memo) {
+    void setDefaultMemo(String memo) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(DEFAULT_MEMO_KEY, memo);
         editor.apply();
     }
 
-    public String getDefaultMemo() {
-        String memo = prefs.getString(DEFAULT_MEMO_KEY, "");
-        return memo;
+    String getDefaultMemo() {
+        return prefs.getString(DEFAULT_MEMO_KEY, "");
     }
 
-    public void setBchdIP(String ip) {
+    void setBchdIP(String ip) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(BCHD_IP_KEY, ip);
         editor.apply();
     }
 
-    public String getBchdIP() {
-        String ip = prefs.getString(BCHD_IP_KEY, "");
-        return ip;
+    String getBchdIP() {
+        return prefs.getString(BCHD_IP_KEY, "");
     }
 
-    public void setBchdUsername(String username) {
+    void setBchdUsername(String username) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(BCHD_USERNAME_KEY, username);
         editor.apply();
     }
 
-    public String getBchdUsername() {
-        String username = prefs.getString(BCHD_USERNAME_KEY, "");
-        return username;
+    String getBchdUsername() {
+        return prefs.getString(BCHD_USERNAME_KEY, "");
     }
 
-    public void setBchdPassword(String password) {
+    void setBchdPassword(String password) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(BCHD_PASSWORD_KEY, password);
         editor.apply();
     }
 
-    public String getBchdPassword() {
-        String password = prefs.getString(BCHD_PASSWORD_KEY, "");
-        return password;
+    String getBchdPassword() {
+        return prefs.getString(BCHD_PASSWORD_KEY, "");
     }
 
-    public void setBchdCert(String cert) {
+    void setBchdCert(String cert) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(BCHD_CERT_KEY, cert);
         editor.apply();
     }
 
-    public String getBchdCert() {
-        String cert = prefs.getString(BCHD_CERT_KEY, "");
-        return cert;
+    String getBchdCert() {
+        return prefs.getString(BCHD_CERT_KEY, "");
     }
 
-    public void setEncryptionType(EncryptionType et) {
+    void setEncryptionType(EncryptionType et) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(ENCRYPTION_TYPE_KEY, et.toString());
         editor.apply();
     }
 
-    public EncryptionType getEncryptionType() {
+    EncryptionType getEncryptionType() {
         String t = prefs.getString(ENCRYPTION_TYPE_KEY, "unencrypted");
         return EncryptionType.fromString(t);
     }
 
-    public void setInvalidPinCount(int count) {
+    void setInvalidPinCount(int count) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putInt(INVALID_PIN_COUNT_KEY, count);
         editor.apply();
     }
 
-    public int getInvalidPinCount() {
-        int count = prefs.getInt(INVALID_PIN_COUNT_KEY, 0);
-        return count;
+    int getInvalidPinCount() {
+        return prefs.getInt(INVALID_PIN_COUNT_KEY, 0);
     }
 
-    public void setLastInvalidPin(long timestamp) {
+    void setLastInvalidPin(long timestamp) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putLong(LAST_INVALID_PIN_KEY, timestamp);
         editor.apply();
     }
 
-    public long getLastInvalidPin() {
-        long timestamp = prefs.getLong(LAST_INVALID_PIN_KEY, 0);
-        return timestamp;
+    long getLastInvalidPin() {
+        return prefs.getLong(LAST_INVALID_PIN_KEY, 0);
     }
 
-    public void setEncryptedPassword(String pw) {
+    void setEncryptedPassword(String pw) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(ENCRYPTED_PASSWORD_KEY, pw);
         editor.apply();
     }
 
-    public String getEncryptedPassword() {
-        String pw = prefs.getString(ENCRYPTED_PASSWORD_KEY, "");
-        return pw;
+    String getEncryptedPassword() {
+        return prefs.getString(ENCRYPTED_PASSWORD_KEY, "");
     }
 
-    public void setFingerprintIv(String iv) {
+    void setFingerprintIv(String iv) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putString(FINGERPRINT_IV_KEY, iv);
         editor.apply();
     }
 
-    public String getFingerprintIv() {
-        String iv = prefs.getString(FINGERPRINT_IV_KEY, "");
-        return iv;
+    String getFingerprintIv() {
+        return prefs.getString(FINGERPRINT_IV_KEY, "");
     }
 
-    public void setLastNotification(long timestamp) {
+    void setLastNotification(long timestamp) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putLong(LAST_NOTIFICATION_KEY, timestamp);
         editor.apply();
     }
 
-    public long getLastNotification() {
-        long timestamp = prefs.getLong(LAST_NOTIFICATION_KEY, 0);
-        return timestamp;
+    long getLastNotification() {
+        return prefs.getLong(LAST_NOTIFICATION_KEY, 0);
     }
 
-    public void setBackupReminder(boolean reminded) {
+    void setBackupReminder(boolean reminded) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putBoolean(BACKUP_REMINDER_KEY, reminded);
         editor.apply();
     }
 
-    public Boolean getBackupReminder() {
-        boolean reminded = prefs.getBoolean(BACKUP_REMINDER_KEY, false);
-        return reminded;
+    Boolean getBackupReminder() {
+        return prefs.getBoolean(BACKUP_REMINDER_KEY, false);
     }
 
     public void setWalletBirthday(long timestamp) {
@@ -291,18 +270,16 @@ public class Settings {
     }
 
     public long getWalletBirthday() {
-        long timestamp = prefs.getLong(WALLET_BIRTHDAY_KEY, 0);
-        return timestamp;
+        return prefs.getLong(WALLET_BIRTHDAY_KEY, 0);
     }
 
-    public void setRepoVersion(int version) {
+    void setRepoVersion(int version) {
         SharedPreferences.Editor editor = this.prefs.edit();
         editor.putInt(REPO_VERSION_KEY, version);
         editor.apply();
     }
 
-    public int getRepoVersion() {
-        int version = prefs.getInt(REPO_VERSION_KEY, 0);
-        return version;
+    int getRepoVersion() {
+        return prefs.getInt(REPO_VERSION_KEY, 0);
     }
 }


### PR DESCRIPTION
- Encapsulation fixes
- Editor/Apply refactor

When/If you merge this, I've found a potential ANR on your MainActivity when you create the `Settings` object.

Doing this at `MainActivity::onCreate` can cause Android apps to freeze on startup:
```java
        SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(this);
        this.settings = new Settings(sharedPref);
```

The IO performed by `PreferenceManager.getDefaultSharedPreferences(this)` leads to common ANR reports in my experience, I believe your `NotificationService` makes another call when the service is created, this can lead to race conditions that trigger the ANR. 

It's better to do that in a background thread and start accessing preferences once available. Perhaps you've not seen this reports yet, but they certainly popped up a lot for us after several thousand instances in the wild.

Again, if you merge this let me know what you think, I'd be happy to do this fix for you.