### PR TITLE
Change green plus to light grey

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -68,6 +68,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
         android:layout_margin="@dimen/fab_margin"
+        android:tint="@color/liteGrey"
         app:srcCompat="@android:drawable/ic_input_add" />
 
     <View


### PR DESCRIPTION
This just changes the green `+/x` icon in the main menu to match the others. Now it uses the light grey tint and looks way cleaner, plus matches the image on the new website.